### PR TITLE
Fix single collection items with a custom `type` key set

### DIFF
--- a/src/generators/collections.js
+++ b/src/generators/collections.js
@@ -41,7 +41,7 @@ export async function getLayout(path, details) {
 		typeFolders.push(type, '/', '_default'); // '/' signifies to use root folder
 		layoutFiles.push(layout, 'index', 'home', 'list');
 	} else if (isSingle) {
-		typeFolders.push(section, '_default');
+		typeFolders.push(type, section, '_default');
 		layoutFiles.push(layout, 'single');
 	} else {
 		typeFolders.push(type, section, 'section', '_default');

--- a/test/generators/collections.test.js
+++ b/test/generators/collections.test.js
@@ -138,6 +138,11 @@ describe('collections generator', function () {
 			expect(result).to.equal('posts/mylayout');
 		});
 
+		it('single post with type set', async function () {
+			const result = await getLayout('content/posts/post.md', { type: 'mytype' });
+			expect(result).to.equal('mytype/single');
+		});
+
 		it('single post with a non-existent type set', async function () {
 			const result = await getLayout('content/posts/post.md', { type: 'invalidType' });
 			expect(result).to.equal('posts/single');

--- a/test/helpers/paths.test.js
+++ b/test/helpers/paths.test.js
@@ -37,7 +37,8 @@ describe('pathHelper', function () {
 				},
 				mytype: {
 					list: 'mytype/list',
-					mylayout: 'mytype/mylayout'
+					mylayout: 'mytype/mylayout',
+					single: "mytype/single"
 				},
 				posts: {
 					mylayout: 'posts/mylayout',

--- a/test/test-paths.js
+++ b/test/test-paths.js
@@ -37,6 +37,7 @@ export const pathsByType = {
 		'layouts/index.html',
 		'layouts/mytype/list.html',
 		'layouts/mytype/mylayout.html',
+		'layouts/mytype/single.html',
 		'layouts/posts/mylayout.html',
 		'layouts/posts/single.html'
 	],


### PR DESCRIPTION
Currently a file at `content/blog/my-post.md` will look for a layout at `layouts/blog/single`, then `layouts/_default/single`. If however that file has `type: post` in the frontmatter, this will be ignored and the layout will not be found (`layouts/post/single`).

We do this for homepages:
https://github.com/CloudCannon/cloudcannon-hugo/blob/36b9c7a6fdc994e9576a9acd065092be790cadaa/test/generators/collections.test.js#L111-L114

And we do this for list pages:
https://github.com/CloudCannon/cloudcannon-hugo/blob/36b9c7a6fdc994e9576a9acd065092be790cadaa/test/generators/collections.test.js#L166-L169

But we never test this for files without the `_index.md` filename, which go down a different codepath. I have added this test (which without the change to `collections.js`, fails):
https://github.com/CloudCannon/cloudcannon-hugo/blob/36b9c7a6fdc994e9576a9acd065092be790cadaa/test/generators/collections.test.js#L141-L144

----

In `collections.js`, this change adds a check for a single file's `type` key when looking for a layout. The following loop handles this being `null`, so it doesn't matter whether it exists or not.