### PR TITLE
Remove Hugo baseURL from collection item URLs

### DIFF
--- a/src/generators/info.js
+++ b/src/generators/info.js
@@ -1,5 +1,5 @@
 import Papa from 'papaparse';
-import { runProcess, getUrlPathname } from '../helpers/helpers.js';
+import { runProcess } from '../helpers/helpers.js';
 import pathHelper from '../helpers/paths.js';
 import chalk from 'chalk';
 import log from '../helpers/logger.js';
@@ -26,7 +26,7 @@ async function getHugoUrls(hugoConfig) {
 	const fileList = Papa.parse(fileCsv, { header: true });
 
 	return fileList.data.reduce((memo, file) => {
-		memo[file.path] = getUrlPathname(file.permalink);
+		memo[file.path] = file.permalink.replace(hugoConfig.baseURL ?? '', '');
 		return memo;
 	}, {});
 }

--- a/src/generators/info.js
+++ b/src/generators/info.js
@@ -26,7 +26,7 @@ async function getHugoUrls(hugoConfig) {
 	const fileList = Papa.parse(fileCsv, { header: true });
 
 	return fileList.data.reduce((memo, file) => {
-		memo[file.path] = file.permalink.replace(hugoConfig.baseURL ?? '', '');
+		memo[file.path] = ('/' + file.permalink.replace(hugoConfig.baseURL ?? '', '')).replace(/^\/\//, '/');
 		return memo;
 	}, {});
 }

--- a/test/integration/collections-config-override.json
+++ b/test/integration/collections-config-override.json
@@ -1,6 +1,6 @@
 {
 	"source": "",
-	"base_url": "",
+	"base_url": "/documentation",
 	"paths": {
 		"source": "",
 		"archetypes": "archetypes",
@@ -23,6 +23,10 @@
 		"staff_members": {
 			"path": "data/staff_members",
 			"output": false
+		},
+		"posts": {
+			"path": "content/posts",
+			"output": true
 		},
 		"nests": {
 			"path": "content/nested/inner",
@@ -94,6 +98,41 @@
 				"title": "item",
 				"layout": "_default/single"
 			}
+		],
+		"posts": [
+			{
+				"path": "content/posts/post1.md",
+				"collection": "posts",
+				"date": "2016-07-20T00:00:00.000Z",
+				"title": "Post1",
+				"categories": [ "sales" ],
+				"author_staff_member": "anna",
+				"url": "/posts/2016/07/20/post1/",
+				"content_path": "posts/post1.md",
+				"layout": "posts/single"
+			  },
+			  {
+				"path": "content/posts/post2.md",
+				"collection": "posts",
+				"date": "2016-08-12T00:00:00.000Z",
+				"title": "Post2",
+				"categories": [ "marketing" ],
+				"author_staff_member": "betty",
+				"url": "/posts/2016/08/12/post2/",
+				"content_path": "posts/post2.md",
+				"layout": "posts/single"
+			  },
+			  {
+				"path": "content/posts/post3.md",
+				"collection": "posts",
+				"date": "2016-08-06T00:00:00.000Z",
+				"title": "Post3",
+				"categories": [ "sales" ],
+				"author_staff_member": "anna",
+				"url": "/posts/2016/08/06/post3/",
+				"content_path": "posts/post3.md",
+				"layout": "posts/single"
+			  }
 		]
 	}
 }

--- a/test/integration/collections-config-override/cloudcannon.config.yaml
+++ b/test/integration/collections-config-override/cloudcannon.config.yaml
@@ -7,3 +7,6 @@ collections_config:
     path: content/nested/inner
     output: true
     parse_branch_index: true
+  posts:
+    path: content/posts
+    output: true

--- a/test/integration/collections-config-override/config.toml
+++ b/test/integration/collections-config-override/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://example.org/"
+baseURL = "http://example.org/documentation"
 languageCode = "en-us"
 title = "Hydra Template"
 disqusShortname = ""


### PR DESCRIPTION
cloudcannon-hugo should not include the baseURL from Hugo in collection item URLs. CloudCannon handles adding this.